### PR TITLE
Fix for negative temperatures

### DIFF
--- a/lib/ds18b20.js
+++ b/lib/ds18b20.js
@@ -43,7 +43,7 @@ var temperature = function(sensor, callback) {
 
       if (arr[1].charAt(0) == 'f') {
           var x = parseInt("0xffff" + arr[1].toString() + arr[0].toString(), 16);
-	        var output = -((~x + 1) * 0.0625);
+	  var output = -((~x + 1) * 0.0625);
           callback(null, output);
 
       } else if (arr[1].charAt(0) == '0') {


### PR DESCRIPTION
Get the temp from the hex bytes at the beginning of the string rather than "t=", which is incorrect below 0C
