### PR TITLE
Precise decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ You can load them from the terminal (or from the bin/modules.sh script).
     });
 
     console.log('Current temperature is' + ds18b20.temperatureSync('10-00080283a977', {parser: 'hex'}));
+    
+### Precision
+
+The default `decimal` parser rounds to the nearest tenth of a degree Celcius. If the intent is to convert the value to Farenhight, the `preciseDecimal` parser can be used to return a non-rounded value that will contain three decimal places of precision.
 
 ## Develop
 

--- a/lib/ds18b20.js
+++ b/lib/ds18b20.js
@@ -48,7 +48,7 @@ function parsePreciseDecimalData(data) {
 
 var parsers = {
   'hex': parseHexData,
-  'decimal': parseDecimalData,,
+  'decimal': parseDecimalData,
   'preciseDecimal': parsePreciseDecimalData,
   'default': parseDecimalData
 };

--- a/lib/ds18b20.js
+++ b/lib/ds18b20.js
@@ -34,9 +34,22 @@ function parseDecimalData(data) {
   throw new Error('Can not get temperature');
 }
 
+function parsePreciseDecimalData(data) {
+  var arr = data.split('\n');
+
+  if (arr[0].indexOf('YES') > -1) {
+    var output = data.match(/t=(-?(\d+))/);
+    return output[1] / 1000;
+  } else if (arr[0].indexOf('NO') > -1) {
+    return false;
+  }
+  throw new Error('Can not get temperature');
+}
+
 var parsers = {
   'hex': parseHexData,
-  'decimal': parseDecimalData,
+  'decimal': parseDecimalData,,
+  'preciseDecimal': parsePreciseDecimalData,
   'default': parseDecimalData
 };
 


### PR DESCRIPTION
Added a `preciseDecimal` parser that returns the un-rounded value from the temp probe.
For my application, I intend to convert to Fahrenheit. I noticed that the decimal parser would round a value of 19.250 to 19.3. If converting to F, 19.250 => 66.65, and 19.3 => 66.74. This is almost a 0.1 degree difference due to rounding. A more precise conversion would be yielded from converting the full 19.250 precision number to F first, then perform rounding to the nearest tenth of a degree.
